### PR TITLE
Add Dockerfile and usage scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM phusion/baseimage
+
+RUN \
+  apt-get update \
+  && apt-get install -y -qq --no-install-recommends \
+    python python-pip \
+  && apt-get -yq autoremove && apt-get -yq clean && rm -rf /var/lib/apt/lists/* \
+    && rm -rf /tmp/* && rm -rf /var/tmp/*
+
+RUN curl https://sdk.cloud.google.com | bash
+ENV PATH="/root/google-cloud-sdk/bin:$PATH"
+# Tell gcloud to save state in /.config so it's easy to override as a mounted volume.
+ENV HOME=/
+
+RUN pip install virtualenv
+COPY . /firecloud-cli
+WORKDIR /firecloud-cli
+RUN ./install.sh
+ENV PATH="/.firecloud-cli/ubin:$PATH"
+
+RUN mkdir /working
+WORKDIR /working
+
+CMD ["firecloud", "--help"]

--- a/README.md
+++ b/README.md
@@ -13,3 +13,20 @@ To install run `./install.sh` and follow the instructions to add ~/.firecloud-cl
 ## Usage
 
 After installation run `firecloud` for usage
+
+## Dockerized Version
+
+No installation necessary. Run:
+```bash
+docker run --rm -it -v "$HOME"/.config:/.config broadinstitute/firecloud-cli gcloud auth login
+```
+
+then:
+```bash
+docker run --rm -it -v "$HOME"/.config:/.config broadinstitute/firecloud-cli firecloud --help
+```
+
+for usage. To read/write files from your current directory, be sure to mount it:
+```bash
+docker run --rm -it -v "$HOME"/.config:/.config -v "$PWD":/working broadinstitute/firecloud-cli firecloud -m push my-file.wdl
+```


### PR DESCRIPTION
This makes it possible to use the CLI without installation provided the user already has docker running on their system (especially helpful for developers testing FireCloud).